### PR TITLE
Feature/auth create

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -5,11 +5,14 @@ import Home from "./pages/Home";
 import Test from "./pages/Test";
 import AuthProvider from "./provider/AuthProvider";
 import Header from "./components/header";
+import GlobalModal from "./components/GlobalModal/GlobalModal";
+
 function App() {
   return (
     <BrowserRouter>
-      <Toast />
       <AuthProvider>
+        <Toast />
+        <GlobalModal />
         <Header />
         <Routes>
           <Route path="/" element={<Home />} />

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -3,14 +3,19 @@ import "./App.css";
 import Toast from "./modules/Toast";
 import Home from "./pages/Home";
 import Test from "./pages/Test";
+import AuthProvider from "./provider/AuthProvider";
+import Header from "./components/header";
 function App() {
   return (
     <BrowserRouter>
       <Toast />
-      <Routes>
-        <Route path='/' element={<Home />} />
-        <Route path='/test' element={<Test />} />
-      </Routes>
+      <AuthProvider>
+        <Header />
+        <Routes>
+          <Route path="/" element={<Home />} />
+          <Route path="/test" element={<Test />} />
+        </Routes>
+      </AuthProvider>
     </BrowserRouter>
   );
 }

--- a/src/api/supabase.ts
+++ b/src/api/supabase.ts
@@ -1,4 +1,5 @@
 import { createClient } from "@supabase/supabase-js";
-const supabaseUrl = process.env.VITE_SUPABASE_KEY as string;
-const supabaseKey = process.env.SUPABASE_KEY as string;
+
+const supabaseUrl = import.meta.env.VITE_SUPABASE_URL as string;
+const supabaseKey = import.meta.env.VITE_SUPABASE_KEY as string;
 export const supabase = createClient(supabaseUrl, supabaseKey);

--- a/src/components/GlobalModal/GlobalModal.tsx
+++ b/src/components/GlobalModal/GlobalModal.tsx
@@ -1,0 +1,19 @@
+import React from "react";
+import { useSetGlobalModal } from "../../store/store";
+
+export default function GlobalModal() {
+  const { component, closeModal } = useSetGlobalModal();
+
+  if (!component) return;
+
+  return (
+    <React.Fragment>
+      <div className="w-fit max-w-[36rem] h-fit max-h-[24rem] absolute top-[50%] left-[50%] translate-x-[-50%] translate-y-[-50%] z-20">
+        {component}
+      </div>
+      <div
+        onClick={closeModal}
+        className="w-dvw bg-[#00000090] h-dvh absolute inset-0 z-10"></div>
+    </React.Fragment>
+  );
+}

--- a/src/components/auth/index.tsx
+++ b/src/components/auth/index.tsx
@@ -1,3 +1,59 @@
+import React from "react";
+import { useAuth } from "../../provider/AuthProvider";
+
 export default function Login() {
-  return <div>Login Page</div>;
+  const { handleUserInput, userInput, signUp, login } = useAuth();
+
+  return (
+    <div className="w-full min-h-screen bg-amber-400 flex flex-col justify-center items-center">
+      <form
+        onSubmit={(e) => e.preventDefault()}
+        className="w-full max-w-[24rem] border-2 border-amber-600 h-[15rem] rounded-[1rem] bg-[#ebebeb90] flex flex-col items-center justify-center gap-4">
+        <h1 className="font-bold text-2xl">로그인</h1>
+
+        <div className="flex items-center gap-3">
+          <label className="w-[5rem]" htmlFor="nickname">
+            닉네임:
+          </label>
+          <input
+            type="text"
+            id="nickname"
+            className="bg-[#fff] rounded-[.4rem] px-2"
+            onChange={(e: React.ChangeEvent<HTMLInputElement>) => {
+              const { value } = e.target;
+              handleUserInput("nickname", value);
+            }}
+          />
+        </div>
+        <div className="flex items-center gap-3">
+          <label className="w-[5rem]" htmlFor="password">
+            비밀번호:
+          </label>
+          <input
+            type="password"
+            id="password"
+            className="bg-[#fff] rounded-[.4rem] px-2"
+            onChange={(e: React.ChangeEvent<HTMLInputElement>) => {
+              const { value } = e.target;
+              handleUserInput("password", value);
+            }}
+          />
+        </div>
+        <p className="text-[.8rem] ">
+          계정이 있다면 비밀번호만 입력해도 로그인 됩니다.
+        </p>
+        <button
+          className="w-full text-black max-w-[18rem] rounded-[.2rem] bg-amber-100 py-1 hover:bg-amber-700 hover:text-amber-50 cursor-pointer"
+          onClick={() => {
+            if (userInput.nickname) {
+              return signUp();
+            } else {
+              return login();
+            }
+          }}>
+          {userInput.nickname ? "회원가입" : "로그인"}
+        </button>
+      </form>
+    </div>
+  );
 }

--- a/src/components/auth/index.tsx
+++ b/src/components/auth/index.tsx
@@ -1,3 +1,3 @@
 export default function Login() {
-  return <div>index</div>;
+  return <div>Login Page</div>;
 }

--- a/src/components/auth/index.tsx
+++ b/src/components/auth/index.tsx
@@ -5,7 +5,7 @@ export default function Login() {
   const { handleUserInput, userInput, signUp, login } = useAuth();
 
   return (
-    <div className="w-full min-h-screen bg-amber-400 flex flex-col justify-center items-center">
+    <div className="w-dvw min-h-screen bg-amber-400 flex flex-col justify-center items-center">
       <form
         onSubmit={(e) => e.preventDefault()}
         className="w-full max-w-[24rem] border-2 border-amber-600 h-[15rem] rounded-[1rem] bg-[#ebebeb90] flex flex-col items-center justify-center gap-4">

--- a/src/components/creatRoomForm/CreateRoomForm.tsx
+++ b/src/components/creatRoomForm/CreateRoomForm.tsx
@@ -1,0 +1,77 @@
+import React, { useState } from "react";
+import { useAuth } from "../../provider/AuthProvider";
+import { supabase } from "../../api/supabase";
+import { ToastPopUp } from "../../modules/Toast";
+import { useQueryClient } from "@tanstack/react-query";
+import { useSetGlobalModal } from "../../store/store";
+
+type RoomInfo = {
+  roomTitle: string;
+};
+
+export default function CreateRoomForm() {
+  const { user } = useAuth();
+  const queryClient = useQueryClient();
+  const { closeModal } = useSetGlobalModal();
+  const [roomInfo, setRoomInfo] = useState<RoomInfo>({
+    roomTitle: "",
+  });
+
+  const handleRoomInfoChange = (type: keyof RoomInfo, value: string) => {
+    setRoomInfo((prev) => ({ ...prev, [type]: value }));
+  };
+
+  const createRoom = async () => {
+    const { error } = await supabase
+      .from("rooms")
+      .insert([{ roomTitle: roomInfo.roomTitle, participant: [user?.id] }])
+      .select();
+
+    if (error) {
+      return ToastPopUp({
+        type: "error",
+        message: "게임 생성 실패",
+      });
+    }
+
+    ToastPopUp({
+      type: "success",
+      message: "게임 생성 완료",
+    });
+    queryClient.invalidateQueries({ queryKey: ["home", "get-room-list"] });
+    closeModal();
+  };
+
+  return (
+    <React.Fragment>
+      <form
+        onSubmit={(e) => e.preventDefault()}
+        className=" min-w-[24rem] max-w-[36rem] border-2 border-amber-600 h-[15rem] rounded-[1rem] bg-[#ebebeb90] flex flex-col items-center justify-center gap-4">
+        <h1 className="font-bold text-2xl">방 만들기</h1>
+
+        <div className="flex items-center gap-3">
+          <label className="w-[5rem]" htmlFor="roomTitle">
+            방 제목:
+          </label>
+          <input
+            type="text"
+            id="roomTitle"
+            className="bg-[#fff] rounded-[.4rem] px-2"
+            onChange={(e) => {
+              const { value } = e.target;
+              handleRoomInfoChange("roomTitle", value);
+            }}
+          />
+        </div>
+
+        <button
+          className="w-full text-black max-w-[18rem] rounded-[.2rem] bg-amber-100 py-1 hover:bg-amber-700 hover:text-amber-50 cursor-pointer"
+          onClick={() => {
+            createRoom();
+          }}>
+          방 생성
+        </button>
+      </form>
+    </React.Fragment>
+  );
+}

--- a/src/components/header/index.tsx
+++ b/src/components/header/index.tsx
@@ -4,10 +4,10 @@ import { useAuth } from "../../provider/AuthProvider";
 export default function Header() {
   const { logout } = useAuth();
   return (
-    <div>
+    <div className="w-dvw h-[3rem] bg-sky-100 flex items-center justify-end px-3">
       <button
         onClick={logout}
-        className="w-[9rem] rounded-[.4rem] bg-slate-700 text-white py-1 absolute top-1.5 right-1.5">
+        className="w-[9rem] rounded-[.4rem] bg-slate-700 text-white py-1 5">
         로그아웃
       </button>
     </div>

--- a/src/components/header/index.tsx
+++ b/src/components/header/index.tsx
@@ -1,0 +1,15 @@
+import React from "react";
+import { useAuth } from "../../provider/AuthProvider";
+
+export default function Header() {
+  const { logout } = useAuth();
+  return (
+    <div>
+      <button
+        onClick={logout}
+        className="w-[9rem] rounded-[.4rem] bg-slate-700 text-white py-1 absolute top-1.5 right-1.5">
+        로그아웃
+      </button>
+    </div>
+  );
+}

--- a/src/hooks/Home/useHome.tsx
+++ b/src/hooks/Home/useHome.tsx
@@ -1,0 +1,35 @@
+import { useQuery } from "@tanstack/react-query";
+import { ToastPopUp } from "../../modules/Toast";
+import { supabase } from "../../api/supabase";
+
+type Room = {
+  id: number;
+  roomTitle: string;
+  gameStatue: object;
+  updatedAt: string;
+  chats: object[];
+  startAt: string;
+  participants: string[];
+};
+
+export default function useHome() {
+  // 수파베이스에서 방 목록 가져오깅
+  const getRooms = async (): Promise<Room[] | void> => {
+    const { data, error } = await supabase.from("rooms").select("*");
+    if (error) {
+      return ToastPopUp({
+        type: "error",
+        message: "방 목록을 못 가져왔어요",
+      });
+    }
+    return data;
+  };
+
+  const { data } = useQuery({
+    queryKey: ["home", "get-room-list"],
+    queryFn: () => {
+      return getRooms();
+    },
+  });
+  return { data, getRooms };
+}

--- a/src/pages/Home/index.tsx
+++ b/src/pages/Home/index.tsx
@@ -1,16 +1,54 @@
-import { ToastPopUp } from "../../modules/Toast";
+import CreateRoomForm from "../../components/creatRoomForm/CreateRoomForm";
+import { useSetGlobalModal } from "../../store/store";
+import useHome from "../../hooks/Home/useHome";
 
 export default function Home() {
-  const test = () => {
-    ToastPopUp({
-      type: "info",
-      message: "테스트 입니다,.",
-    });
-  };
+  const { setModal } = useSetGlobalModal();
+  const { data: roomList } = useHome();
 
   return (
-    <div>
-      <button onClick={test}>click</button>
+    <div className="relative ">
+      <table className="table-fixed w-full border-1 border-y-slate-600">
+        <thead className="font-extrabold">
+          <tr>
+            <td className="border-1 border-y-slate-600 text-center py-0.5">
+              방 제목
+            </td>
+            <td className="border-1 border-y-slate-600 text-center py-0.5">
+              참여 인원
+            </td>
+            <td className="border-1 border-y-slate-600 text-center py-0.5">
+              생성 시간
+            </td>
+          </tr>
+        </thead>
+        <tbody>
+          {roomList?.map((room) => {
+            return (
+              <tr>
+                <td className="border-1 border-y-slate-600 text-center py-1">
+                  {room?.roomTitle}
+                </td>
+                <td className="border-1 border-y-slate-600 text-center py-1">
+                  {room?.participants?.length || 0} 명
+                </td>
+                <td className="border-1 border-y-slate-600 text-center py-1">
+                  {`${room?.startAt.split("T")[0]} - ${String(
+                    room?.startAt.split("T")[1]
+                  ).slice(0, 8)}`}
+                </td>
+              </tr>
+            );
+          })}
+        </tbody>
+      </table>
+      <button
+        onClick={() => {
+          setModal(<CreateRoomForm />);
+        }}
+        className="min-w-[9rem] py-1 rounded-[.6rem] bg-amber-500 text-slate-50 cursor-pointer hover:bg-amber-700 hover:text-amber-300 fixed bottom-3.5 left-3.5">
+        방 만들기
+      </button>
     </div>
   );
 }

--- a/src/pages/Home/index.tsx
+++ b/src/pages/Home/index.tsx
@@ -1,4 +1,3 @@
-import React from "react";
 import { ToastPopUp } from "../../modules/Toast";
 
 export default function Home() {
@@ -11,7 +10,7 @@ export default function Home() {
 
   return (
     <div>
-      <button onClick={test}>click</button>Home
+      <button onClick={test}>click</button>
     </div>
   );
 }

--- a/src/provider/AuthProvider.tsx
+++ b/src/provider/AuthProvider.tsx
@@ -1,0 +1,116 @@
+import React, { createContext, useContext, useState } from "react";
+import { supabase } from "../api/supabase";
+import { ToastPopUp } from "../modules/Toast";
+import Login from "../components/auth";
+
+interface AuthProviderType {
+  user: User | null;
+  signUp: (user: User) => Promise<unknown>;
+  login: (password: string) => Promise<unknown>;
+  userInput: User;
+  handleUserInput: (type: keyof User, value: string) => void;
+  // logout: () => Promise<unknown>;
+}
+
+const AuthContext = createContext<AuthProviderType | undefined>(undefined);
+
+type User = {
+  nickname: string;
+  password: string;
+  room?: number | null;
+};
+
+type Props = {
+  children: React.ReactNode;
+};
+
+// 로그인 상태에 따라 보여지는 페이지가 다릅니당
+export default function AuthProvider({ children }: Props) {
+  const [userInput, setUserInput] = useState<User>({
+    nickname: "",
+    password: "",
+  });
+
+  const [user, setUser] = useState<User>({
+    nickname: "",
+    password: "",
+    room: null,
+  });
+
+  const handleUserInput = (type: keyof User, value: string) => {
+    setUserInput((prev) => ({ ...prev, [type]: value }));
+  };
+
+  const signUp = async (userInput: User) => {
+    const { nickname, password } = userInput;
+    try {
+      const { error } = await supabase
+        .from("users")
+        .insert([{ nickname, password }])
+        .select();
+
+      ToastPopUp({
+        type: "success",
+        message: "회원가입 성공",
+      });
+    } catch (error) {
+      ToastPopUp({
+        type: "error",
+        message: `백엔드 잘못입니다.`,
+      });
+      return error;
+    }
+  };
+
+  const login = async (password: string) => {
+    try {
+      const { data } = await supabase
+        .from("users")
+        .select("*")
+        .eq("password", password);
+
+      if (data) {
+        ToastPopUp({
+          type: "success",
+          message: "로그인 성공",
+        });
+
+        setUser(data[0] as User);
+
+        return data;
+      }
+    } catch (error) {
+      ToastPopUp({
+        type: "error",
+        message: "로그인 실패",
+      });
+      return error;
+    }
+  };
+
+  // const logout = async () => {
+  //   try {
+  //     //
+  //   } catch (error) {
+  //     //
+  //   }
+  // };
+
+  return (
+    <AuthContext.Provider
+      value={{ user, userInput, handleUserInput, signUp, login }}>
+      {user ? children : <Login />}
+    </AuthContext.Provider>
+  );
+}
+
+// auth 훅
+export const useAuth = () => {
+  const context = useContext(AuthContext);
+
+  if (!context) {
+    ToastPopUp({ type: "error", message: "유저 정보가 없습니다." });
+  }
+
+  return context;
+};

--- a/src/provider/AuthProvider.tsx
+++ b/src/provider/AuthProvider.tsx
@@ -8,7 +8,7 @@ interface AuthProviderType {
   user: User | null;
   signUp: () => Promise<unknown>;
   login: () => Promise<unknown>;
-  userInput: User;
+  userInput: Partial<User>;
   handleUserInput: (type: keyof User, value: string) => void;
   logout: () => void;
 }
@@ -16,6 +16,7 @@ interface AuthProviderType {
 const AuthContext = createContext<AuthProviderType | undefined>(undefined);
 
 type User = {
+  id: string | null;
   nickname: string;
   password: string;
   room?: number | null;
@@ -29,13 +30,13 @@ type Props = {
 export default function AuthProvider({ children }: Props) {
   const {
     user,
-    login: handleLoginState,
     setUser,
+    login: handleLoginState,
     logout: userSessionClear,
     isLogined,
   } = useAuthStore();
 
-  const [userInput, setUserInput] = useState<User>({
+  const [userInput, setUserInput] = useState<Partial<User>>({
     nickname: "",
     password: "",
   });
@@ -70,8 +71,8 @@ export default function AuthProvider({ children }: Props) {
         .eq("password", userInput.password);
 
       if (data) {
-        const { nickname, password, room } = data[0] as User;
-        setUser({ nickname, password, room });
+        const { nickname, password, room, id } = data[0] as User;
+        setUser({ id, nickname, password, room });
         handleLoginState();
         ToastPopUp({
           type: "success",

--- a/src/store/store.ts
+++ b/src/store/store.ts
@@ -1,0 +1,42 @@
+import { create } from "zustand";
+import { persist } from "zustand/middleware";
+
+type UserInfo = {
+  nickname: string;
+  room: number | null | undefined;
+  password: string;
+};
+
+type AuthStore = {
+  isLogined: boolean;
+  user: { nickname: string; password: string; room: number | null };
+  setUser: (data: UserInfo) => void;
+  logout: () => void;
+  login: () => void;
+};
+
+export const useAuthStore = create(
+  persist<AuthStore>(
+    (set) => ({
+      isLogined: false,
+      user: { nickname: "", password: "", room: null },
+      setUser: (data: UserInfo) =>
+        set({
+          user: {
+            nickname: data.nickname,
+            password: "",
+            room: data.room || null,
+          },
+        }),
+      login: () => set({ isLogined: true }),
+      logout: () =>
+        set({
+          isLogined: false,
+          user: { nickname: "", password: "", room: null },
+        }),
+    }),
+    {
+      name: "userStorage",
+    }
+  )
+);

--- a/src/store/store.ts
+++ b/src/store/store.ts
@@ -2,6 +2,7 @@ import { create } from "zustand";
 import { persist } from "zustand/middleware";
 
 type UserInfo = {
+  id: string | null;
   nickname: string;
   room: number | null | undefined;
   password: string;
@@ -9,7 +10,12 @@ type UserInfo = {
 
 type AuthStore = {
   isLogined: boolean;
-  user: { nickname: string; password: string; room: number | null };
+  user: {
+    id: string | null;
+    nickname: string;
+    password: string;
+    room: number | null;
+  };
   setUser: (data: UserInfo) => void;
   logout: () => void;
   login: () => void;
@@ -19,10 +25,11 @@ export const useAuthStore = create(
   persist<AuthStore>(
     (set) => ({
       isLogined: false,
-      user: { nickname: "", password: "", room: null },
+      user: { id: null, nickname: "", password: "", room: null },
       setUser: (data: UserInfo) =>
         set({
           user: {
+            id: data.id,
             nickname: data.nickname,
             password: "",
             room: data.room || null,
@@ -32,7 +39,7 @@ export const useAuthStore = create(
       logout: () =>
         set({
           isLogined: false,
-          user: { nickname: "", password: "", room: null },
+          user: { id: null, nickname: "", password: "", room: null },
         }),
     }),
     {
@@ -40,3 +47,18 @@ export const useAuthStore = create(
     }
   )
 );
+
+type GlobalModalStore = {
+  isOpened: boolean;
+  setModal: (component: JSX.Element) => void;
+  closeModal: () => void;
+  component: JSX.Element | null;
+};
+
+export const useSetGlobalModal = create<GlobalModalStore>((set) => ({
+  isOpened: false,
+  setModal: (component: JSX.Element) =>
+    set({ component: component, isOpened: true }),
+  closeModal: () => set({ component: null, isOpened: false }),
+  component: null,
+}));


### PR DESCRIPTION
- authStore 생성
유저의 로그인 정보를 전역 상태로 관리합니다.

- AuthProvider 적용
내부적으로 user 정보의 유무에 따라서 라우팅을 다르게 합니다.
유저 정보가 있다면 children, 없다면 로그인/회원가입 페이지.

- 임시 헤더 + 로그아웃 버튼 적용

- 전역 모달 생성 (GlobalModal)
  - **useSetGlobalModal**  훅을 사용하여 제어

- 방 만들기 기능 추가